### PR TITLE
changed my update to use rename instead, restored old update mapping

### DIFF
--- a/src/main/java/com/revature/_1811_nov27_wvu/icebox/controller/FileController.java
+++ b/src/main/java/com/revature/_1811_nov27_wvu/icebox/controller/FileController.java
@@ -60,8 +60,8 @@ public class FileController {
 	}
 
 	@RequestMapping(value = "/api/files/rename", method = RequestMethod.POST)
-	public File updateFile(@RequestBody File f) {
-		fs.updateFile(f);
+	public File renameFile(@RequestBody File f) {
+		fs.renameFile(f);
 		return f;
 	}
 

--- a/src/main/java/com/revature/_1811_nov27_wvu/icebox/dao/FileDao.java
+++ b/src/main/java/com/revature/_1811_nov27_wvu/icebox/dao/FileDao.java
@@ -25,4 +25,6 @@ public interface FileDao {
 	Set<File> getFilesByTag(String s, User u);
 	
 	Set<File> getFilesByName(String s, User u);
+
+	File renameFile(File f);
 }

--- a/src/main/java/com/revature/_1811_nov27_wvu/icebox/dao/FileHibernate.java
+++ b/src/main/java/com/revature/_1811_nov27_wvu/icebox/dao/FileHibernate.java
@@ -50,7 +50,7 @@ public class FileHibernate implements FileDao {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public File updateFile(File f) {
+	public File renameFile(File f) {
 		Session s = sf.getSession();
 		Transaction tx = s.beginTransaction();
 		Query<File> q = s.createQuery("update File set name = :name" +
@@ -130,6 +130,16 @@ public class FileHibernate implements FileDao {
 		q.setParameter("ownId", u.getId());
 		Set<File> shareSet = new HashSet<File>(q.getResultList());
 		return shareSet;
+	}
+
+	@Override
+	public File updateFile(File f) {
+		Session s = sf.getSession();
+		Transaction tx = s.beginTransaction();
+		s.update(f);
+		tx.commit();
+		s.close();
+		return f;
 	}
 
 }

--- a/src/main/java/com/revature/_1811_nov27_wvu/icebox/services/FileService.java
+++ b/src/main/java/com/revature/_1811_nov27_wvu/icebox/services/FileService.java
@@ -37,4 +37,6 @@ public interface FileService {
 	public Set<File> getFilesByFolder(int i);
 
 	public Set<File> getFileBySearch(String s, User u);
+
+	public File renameFile(File f);
 }

--- a/src/main/java/com/revature/_1811_nov27_wvu/icebox/services/FileServiceImpl.java
+++ b/src/main/java/com/revature/_1811_nov27_wvu/icebox/services/FileServiceImpl.java
@@ -144,4 +144,9 @@ public class FileServiceImpl implements FileService {
 			return Pair.of(new ByteArrayInputStream(o), Long.valueOf(o.length));
 		}
 	}
+
+	@Override
+	public File renameFile(File f) {
+		return fd.renameFile(f);
+	}
 }


### PR DESCRIPTION
Both features now work as intended, fixed the issue where both mappings were using the same function, causing share string generation to fail